### PR TITLE
Slightly hacky version of optional per-user auth

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,10 @@
       "source" : "/source",
       "destination" : "https://github.com/inlined/alone-together",
       "type" : 302
-    } ]
+    } ],
+    "rewrites": [{
+      "source": "/rating",
+      "function": "rating"
+    }]
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,7 +5,9 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@types/express": "^4.0.39",
     "@types/lodash": "^4.14.78",
+    "express": "^4.16.2",
     "firebase-admin": "~5.4.2",
     "firebase-functions": "^0.7.1",
     "lodash": "^4.17.4",

--- a/functions/src/demo-helper.ts
+++ b/functions/src/demo-helper.ts
@@ -1,7 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import * as Twitter from 'twitter';
-import * as https from 'https';
+import {Request} from 'express';
 
 export const resetAggregate = functions.database.ref('aggregate').onDelete(async event => {
     const stat = {
@@ -26,15 +26,16 @@ export const resetAggregate = functions.database.ref('aggregate').onDelete(async
     await admin.database().ref('aggregate').set(stat);
 });
 
-export function authenticateTwitter(req: https.Request) {
+export function authenticateTwitter(req: Request) {
   // The twitter config value is expected to hold consumer_key, consumer_secret, access_token_key, and
   // access_token_secret. To help the demo along, we allow a fallback to use hard-coded credentials
   // from firebase config when the request has no authentication header.
   const config = functions.config().twitter;
 
-  if (req.headers.authentication && req.headers.authentication.startsWith('Basic ')) {
+  const auth = req.headers.authentication as string;
+  if (auth && auth.startsWith('Basic ')) {
     console.log('Using request-based authentication');
-    const encoded = req.headers.authentication.slice('Basic '.length);
+    const encoded = auth.slice('Basic '.length);
     [config.access_token_key, config.access_token_secret] =
       encoded.split('+').map(part => Buffer.from(part, 'base64').toString());
   }

--- a/functions/src/demo-helper.ts
+++ b/functions/src/demo-helper.ts
@@ -1,5 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
+import * as Twitter from 'twitter';
+import * as https from 'https';
 
 export const resetAggregate = functions.database.ref('aggregate').onDelete(async event => {
     const stat = {
@@ -23,3 +25,19 @@ export const resetAggregate = functions.database.ref('aggregate').onDelete(async
     stat.ratioMoreFamousThanPeers = stat.moreFamousThanPeers / stat.total;
     await admin.database().ref('aggregate').set(stat);
 });
+
+export function authenticateTwitter(req: https.Request) {
+  // The twitter config value is expected to hold consumer_key, consumer_secret, access_token_key, and
+  // access_token_secret. To help the demo along, we allow a fallback to use hard-coded credentials
+  // from firebase config when the request has no authentication header.
+  const config = functions.config().twitter;
+
+  if (req.headers.authentication && req.headers.authentication.startsWith('Basic ')) {
+    console.log('Using request-based authentication');
+    const encoded = req.headers.authentication.slice('Basic '.length);
+    [config.access_token_key, config.access_token_secret] =
+      encoded.split('+').map(part => Buffer.from(part, 'base64').toString());
+  }
+
+  return new Twitter(config);
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,6 @@ import * as admin from 'firebase-admin';
 import * as Twitter from 'twitter';
 import * as _ from 'lodash';
 import * as helper from './demo-helper';
-export {helper};
 
 admin.initializeApp(functions.config().firebase);
 
@@ -79,9 +78,9 @@ export const aggregate = functions.database.ref('stats/{username}').onCreate(asy
     const res = val || {moreFamousThanPeers: 0, lessFamousThanPeers: 0, total: 0, ratioMoreFamousThanPeers: 0};
     console.log('Prior to update, stats are: ' + JSON.stringify(res, null, 2));
     if (moreFamousThanFriends) {
-      res.lessFamousThanPeers += 1;
-    } else {
       res.moreFamousThanPeers += 1;
+    } else {
+      res.lessFamousThanPeers += 1;
     }
     res.total += 1;
     res.ratioMoreFamousThanPeers = res.moreFamousThanPeers / res.total;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,25 +2,23 @@ import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import * as Twitter from 'twitter';
 import * as _ from 'lodash';
+import * as helper from './demo-helper';
+export {helper};
 
-// The twitter config value is expected to hold consumer_key, consumer_secret, access_token_key, and
-// access_token_secret. Technically we should either fetch application credentials or use a unique credential per user,
-// but this doesn't really add value to the demo.
-const twitter = new Twitter(functions.config().twitter);
 admin.initializeApp(functions.config().firebase);
 
-async function getFriends(user: string): Promise<string[]> {
+async function getFriends(twitter: Twitter, user: string): Promise<string[]> {
   // Note: More code is needed to support users following more than 5K people.
   const response = await twitter.get('friends/ids', {screen_name: user, stringify_ids: true});
   return response.ids;
 }
 
-async function lookupUser(user: string): Promise<Twitter.UserLookupResult> {
+async function lookupUser(twitter: Twitter, user: string): Promise<Twitter.UserLookupResult> {
   const responses = await twitter.get('users/lookup', {screen_name: user} );
   return responses[0];
 }
 
-async function getFollowerCount(ids: string[]) {
+async function getFollowerCount(twitter: Twitter, ids: string[]) {
   const responses = await twitter.get('users/lookup', {user_id: ids.join(',')});
   // Responses is an array of user profiles; we only care about the followers count
   return responses.map(response => response.followers_count);
@@ -33,19 +31,20 @@ export let USER_LOOKUP_BATCH_SIZE = 100;
 export const rating = functions.https.onRequest(async (req, res) => {
   try {
     const username = req.query.username;
+    const twitter = helper.authenticateTwitter(req);
 
     // 0. Get my follower count:
-    const me = await lookupUser(username);
+    const me = await lookupUser(twitter, username);
 
 
     // 1. Get the list of people this user follows:
-    const myFriendsIds = await getFriends(username);
+    const myFriendsIds = await getFriends(twitter, username);
 
     // 2. Break this into groups no larger than Twitter's maximum batch size:
     const batches = _.chunk(myFriendsIds, USER_LOOKUP_BATCH_SIZE);
 
     // 3. Get the follower count for each batch in parallel.
-    const getFriendsFame = batches.map(batch => getFollowerCount(batch));
+    const getFriendsFame = batches.map(batch => getFollowerCount(twitter, batch));
 
     // 4. Wait for all batches to be returned.
     const friendsFameBatches = await Promise.all(getFriendsFame);

--- a/public/index.html
+++ b/public/index.html
@@ -13,27 +13,21 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class = "text-container">
-      <span class = "stat" id="less-famous"></span>&nbsp;&nbsp;people are less famous than their friends.
+    <div class="text-container">
+      <span class="stat" id="less-famous"></span>&nbsp;&nbsp;people are less famous than their friends.
       <p>
-      <span class = "stat" id="more-famous"></span>&nbsp;&nbsp;people are more famous than their friends.
+      <span class="stat" id="more-famous"></span>&nbsp;&nbsp;people are more famous than their friends.
       <p>
-      <span class = "stat" id="percent-famous"></span>&nbsp;&nbsp;of people are more famous than their friends.
+      <span class="stat" id="percent-famous"></span>&nbsp;&nbsp;of people are more famous than their friends.
       <p>
-      <span class = "join" id="join"></span>
+      <span id="join"></span>
+      </p>
     </div>
     <!-- end of body -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
         console.log('dom loaded');
-        firebase.database().ref('/aggregate').on('value', function(snapshot) {
-          const result = snapshot.val();
-          console.log(result);
-          document.getElementById('more-famous').innerHTML = result.moreFamousThanPeers || 0;
-          document.getElementById('less-famous').innerHTML = result.lessFamousThanPeers || 0;
-          const percent = Math.round(result.ratioMoreFamousThanPeers * 100) || 0;
-          document.getElementById('percent-famous').innerHTML = percent + '%';
-        });
+        firebase.database().ref('/aggregate').on('value', updateStats);
 
         // Twitter possibilities:
         // 1. They are not logged in
@@ -51,11 +45,11 @@
             headers: {
               'Authentication': 'Basic ' + secret
             }
-          }).then(function(stats) {
-            console.log('Personal stats:', stats);
-          });
+          }).then(showPersonalStats);
         }).catch(function(err) {
           console.log('Failed to get redirect result with error', err);
+          document.getElementById('join').innerHTML =
+          '<a href="#" class="error-prompt" onClick="authWithTwitter()">Error logging in, try again.</a>';
         });
 
         firebase.auth().onAuthStateChanged(function(user) {
@@ -64,25 +58,44 @@
             promptTwitter();
             return;
           } else {
-            thankTwitter();
+            emptyPrompt();
           }
           // If the user is just now logging in we'll get that from the redirect result.
         })
       });
 
-      function promptTwitter() {
-        document.getElementById('join').innerHTML =
-          '<a href="#" onClick="authWithTwitter()">Test with your Twitter account</a>';
+      function updateStats(snapshot) {
+        const result = snapshot.val();
+        console.log(result);
+        document.getElementById('more-famous').innerHTML = result.moreFamousThanPeers || 0;
+        document.getElementById('less-famous').innerHTML = result.lessFamousThanPeers || 0;
+        const percent = Math.round(result.ratioMoreFamousThanPeers * 100) || 0;
+        document.getElementById('percent-famous').innerHTML = percent + '%';
       }
 
-      function thankTwitter() {
-        document.getElementById('join').innerHTML = 'Thank you for joining the experiment';
+      function promptTwitter() {
+        document.getElementById('join').innerHTML =
+          '<a href="#" class="join-prompt" onClick="authWithTwitter()">Add your stat</a>';
+      }
+
+      function emptyPrompt() {
+        document.getElementById('join').innerHTML = '';
       }
 
       function authWithTwitter() {
         var provider = new firebase.auth.TwitterAuthProvider();
         firebase.auth().signInWithRedirect(provider);
         return false;
+      }
+
+      function showPersonalStats(response) {
+        response.json().then(function(result) {
+          // sample response: {username: "laurenzlong", moreFamousFriendRatio: 0.4062863795110594}
+          var moreFamousPercent = Math.round(result.moreFamousFriendRatio * 100);
+          document.getElementById('join').innerHTML =
+            '<span class ="personal-stat">' + result.username + ' ' + moreFamousPercent +
+            ' % of your friends are more famous than you.</span>';
+        }).catch(console.error)
       }
 
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,6 @@
           }).then(function(stats) {
             console.log('Personal stats:', stats);
           });
-          console.log('Credential is', JSON.stringify(result));
         }).catch(function(err) {
           console.log('Failed to get redirect result with error', err);
         });

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <title>Alone Together</title>
     <script defer src="/__/firebase/4.6.0/firebase-app.js"></script>
     <script defer src="/__/firebase/4.6.0/firebase-database.js"></script>
+    <script defer src="/__/firebase/4.6.0/firebase-auth.js"></script>
     <!-- initialize the SDK after all desired features are loaded -->
     <script defer src="/__/firebase/init.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
@@ -18,12 +19,14 @@
       <span class = "stat" id="more-famous"></span>&nbsp;&nbsp;people are more famous than their friends.
       <p>
       <span class = "stat" id="percent-famous"></span>&nbsp;&nbsp;of people are more famous than their friends.
+      <p>
+      <span class = "join" id="join"></span>
     </div>
     <!-- end of body -->
     <script>
       document.addEventListener('DOMContentLoaded', function() {
-        console.log('dom loaded')
-        firebase.database().ref('/aggregate').on('value', snapshot => {
+        console.log('dom loaded');
+        firebase.database().ref('/aggregate').on('value', function(snapshot) {
           const result = snapshot.val();
           console.log(result);
           document.getElementById('more-famous').innerHTML = result.moreFamousThanPeers || 0;
@@ -31,7 +34,58 @@
           const percent = Math.round(result.ratioMoreFamousThanPeers * 100) || 0;
           document.getElementById('percent-famous').innerHTML = percent + '%';
         });
+
+        // Twitter possibilities:
+        // 1. They are not logged in
+        // 2. They were already logged in
+        // 3. They just logged in
+        firebase.auth().getRedirectResult().then(function(result) {
+          if (result.user === null) {
+            console.log('Redirect result is null');
+            promptTwitter();
+            return;
+          }
+
+          var secret = btoa(result.credential.accessToken) + '+' + btoa(result.credential.secret);
+          fetch('/rating?username=' + result.additionalUserInfo.username, {
+            headers: {
+              'Authentication': 'Basic ' + secret
+            }
+          }).then(function(stats) {
+            console.log('Personal stats:', stats);
+          });
+          console.log('Credential is', JSON.stringify(result));
+        }).catch(function(err) {
+          console.log('Failed to get redirect result with error', err);
+        });
+
+        firebase.auth().onAuthStateChanged(function(user) {
+          console.log("user state change:", user);
+          if (!user) {
+            promptTwitter();
+            return;
+          } else {
+            thankTwitter();
+          }
+          // If the user is just now logging in we'll get that from the redirect result.
+        })
       });
+
+      function promptTwitter() {
+        document.getElementById('join').innerHTML =
+          '<a href="#" onClick="authWithTwitter()">Test with your Twitter account</a>';
+      }
+
+      function thankTwitter() {
+        document.getElementById('join').innerHTML = 'Thank you for joining the experiment';
+      }
+
+      function authWithTwitter() {
+        var provider = new firebase.auth.TwitterAuthProvider();
+        firebase.auth().signInWithRedirect(provider);
+        return false;
+      }
+
     </script>
   </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -12,8 +12,8 @@ body {
 }
 
 .text-container {
-  margin-left: 15%;
-  margin-top: 10%;
+  padding: 5%;
+  text-align: center;
 }
 
 .stat {
@@ -31,4 +31,22 @@ body {
 
 #percent-famous {
   color: #FF8A65;
+}
+
+.join-prompt {
+  text-decoration: none;
+  color: #039BE5;
+}
+
+.join-prompt:hover {
+  text-decoration: underline;
+}
+
+.error-prompt {
+  text-decoration: none;
+  color: #FF8A65;
+}
+
+.personal-stat {
+  color: #F57C00;
 }


### PR DESCRIPTION
Here's something we can optionally use for our code samples & demo. I would briefly gloss over the fact that authenticating twitter doesn't really contribute to the demo and that I've implemented it in a helper function.

OAuth1 is a bit clunky and there's no real reason to build a fully-functional OAuth 1 library for our private API which is backed by an SDK that supports OAuth. Instead, I took a suggestion from Bleigh and just base64 encoded the oauth1 access token and secret into a Basic request header. The helper function to initialize the Twitter SDK will then look at the request header to see if there's a per-user Auth credential available and otherwise uses the fallback credential from firebase config.

With this, we can safely let people try the real app at any point in the demo. If we want to battle test this we can deploy from the branch in the morning and let teammates try the demo out.

